### PR TITLE
TASK: Enable translation of validation errors

### DIFF
--- a/Resources/Private/Fusion/Core/FormElement.fusion
+++ b/Resources/Private/Fusion/Core/FormElement.fusion
@@ -71,7 +71,7 @@ prototype(Neos.Form.FusionRenderer:FormElementValidationErrors) < prototype(Neos
     content = Neos.Fusion:Collection {
         collection = ${elementValidationErrors}
         itemName = 'error'
-        itemRenderer =  ${error}
+        itemRenderer = ${Translation.translate(error.code, null, error.arguments, 'ValidationErrors', element.renderingOptions.validationErrorTranslationPackage)}
     }
     @if.hasValidationErrors = ${elementHasValidationErrors}
 }


### PR DESCRIPTION
The validation errors are currently not translated with the FusionRenderer prototype.

This commit translates these error messages as it is done in
Neos.Form/Resources/Private/Form/Layouts/Field.html with the translation
ViewHelper.