### PR TITLE
BUGFIX: Apply FormElement wrapping before invoking renderCallbacks

### DIFF
--- a/Resources/Private/Fusion/Core/FormElement.fusion
+++ b/Resources/Private/Fusion/Core/FormElement.fusion
@@ -7,15 +7,15 @@ prototype(Neos.Form.FusionRenderer:FormElement) < prototype(Neos.Fusion:Array) {
     label = Neos.Form.FusionRenderer:FormElementLabel
     fieldContainer = Neos.Form.FusionRenderer:FormElementFieldContainer
 
-    @process.renderCallbacks = Neos.Form.FusionRenderer:RenderCallbacks {
-        formRuntime = ${formRuntime}
-        formElement = ${element}
-    }
-
     @process.wrap = Neos.Fusion:Tag {
         tagName = 'div'
         attributes.class = ${hasValidationErrors ? 'clearfix error' : 'clearfix'}
         content = ${value}
+    }
+
+    @process.renderCallbacks = Neos.Form.FusionRenderer:RenderCallbacks {
+        formRuntime = ${formRuntime}
+        formElement = ${element}
     }
 
 }

--- a/Resources/Private/Fusion/Core/FormElement.fusion
+++ b/Resources/Private/Fusion/Core/FormElement.fusion
@@ -14,6 +14,7 @@ prototype(Neos.Form.FusionRenderer:FormElement) < prototype(Neos.Fusion:Array) {
     }
 
     @process.renderCallbacks = Neos.Form.FusionRenderer:RenderCallbacks {
+        @position = 'end'
         formRuntime = ${formRuntime}
         formElement = ${element}
     }


### PR DESCRIPTION
This adjusts the order of `@process.wrap` to happen *before*
`@process.renderCallbacks` so that the whole output of the FormElement
is passed to the callback.

Fixes: #10