### PR TITLE
TASK: Extract hardcoded fusion path

### DIFF
--- a/Classes/FusionFormRenderer.php
+++ b/Classes/FusionFormRenderer.php
@@ -40,6 +40,12 @@ class FusionFormRenderer implements RendererInterface
      */
     protected $packageManager;
 
+    /**
+     * @Flow\InjectConfiguration(path="fusionPathPatterns", package="Neos.Form.FusionRenderer")
+     * @var array
+     */
+    protected $fusionPathPatterns;
+
     public function setControllerContext(ControllerContext $controllerContext)
     {
         $this->controllerContext = $controllerContext;
@@ -87,12 +93,10 @@ class FusionFormRenderer implements RendererInterface
         $fusionView->setControllerContext($this->controllerContext);
         $fusionView->disableFallbackView();
         $fusionView->setPackageKey('Neos.Form.FusionRenderer');
-        $fusionView->setFusionPathPatterns([
-            $this->packageManager->getPackage('Neos.Fusion')->getResourcesPath() . 'Private/Fusion',
-            $this->packageManager->getPackage('Neos.Form.FusionRenderer')->getResourcesPath() . 'Private/Fusion/Core',
-            $this->packageManager->getPackage('Neos.Form.FusionRenderer')->getResourcesPath() . 'Private/Fusion/ContainerElements',
-            $this->packageManager->getPackage('Neos.Form.FusionRenderer')->getResourcesPath() . 'Private/Fusion/Elements',
-        ]);
+        $fusionView->setFusionPathPatterns(array_map(function (string $value) {
+            list($packageKey, $path) = explode(':', $value);
+            return $this->packageManager->getPackage($packageKey)->getResourcesPath() . $path;
+        }, array_keys(array_filter($this->fusionPathPatterns))));
         $fusionView->setFusionPath('neos_form');
         $fusionView->assign('formRuntime', $formRuntime);
         return $fusionView->render();

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -1,5 +1,12 @@
 Neos:
   Form:
+    FusionRenderer:
+      fusionPathPatterns:
+        Neos.Fusion:Private/Fusion: true
+        Neos.Form.FusionRenderer:Private/Fusion/Core: true
+        Neos.Form.FusionRenderer:Private/Fusion/ContainerElements: true
+        Neos.Form.FusionRenderer:Private/Fusion/Elements: true
+
     presets:
       'fusion':
         title: 'Fusion based Form Elements'


### PR DESCRIPTION
The hardcoded values are extracted to `Settings.yaml`. This change allow the usage of custom Fusion prototype in the rendering.

Fixes #9 