### PR TITLE
BUGFIX: Use full package key as Eel helper namespace

### DIFF
--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -20,4 +20,4 @@ Neos:
 
   Fusion:
     defaultContext:
-      'Neos.Form': 'Neos\Form\FusionRenderer\Eel\Helper\FormHelper'
+      'Neos.Form.FusionRenderer': 'Neos\Form\FusionRenderer\Eel\Helper\FormHelper'

--- a/Resources/Private/Fusion/ContainerElements/PreviewPage.fusion
+++ b/Resources/Private/Fusion/ContainerElements/PreviewPage.fusion
@@ -7,11 +7,11 @@ prototype(Neos.Form:PreviewPage) < prototype(Neos.Form.FusionRenderer:AbstractSe
                 content = Neos.Fusion:Array {
                     1 = Neos.Fusion:Tag {
                         tagName = 'th'
-                        content = ${Neos.Form.translate(containerElement, 'forms.pages.labelTitle', 'Label')}
+                        content = ${Neos.Form.FusionRenderer.translate(containerElement, 'forms.pages.labelTitle', 'Label')}
                     }
                     2 = Neos.Fusion:Tag {
                         tagName = 'th'
-                        content = ${Neos.Form.translate(containerElement, 'forms.pages.valueTitle', 'Value')}
+                        content = ${Neos.Form.FusionRenderer.translate(containerElement, 'forms.pages.valueTitle', 'Value')}
                     }
                 }
             }
@@ -58,7 +58,7 @@ prototype(Neos.Form:PreviewPage.ElementRow) < prototype(Neos.Fusion:Tag) {
 }
 
 prototype(Neos.Form:PreviewPage.ElementValue) < prototype(Neos.Fusion:Case) {
-    @context.elementValue = ${Neos.Form.elementValue(formRuntime, element)}
+    @context.elementValue = ${Neos.Form.FusionRenderer.elementValue(formRuntime, element)}
     imageUpload {
         renderer = Neos.Fusion:Tag {
             tagName = 'a'

--- a/Resources/Private/Fusion/Core/AbstractSection.fusion
+++ b/Resources/Private/Fusion/Core/AbstractSection.fusion
@@ -8,7 +8,7 @@ prototype(Neos.Form.FusionRenderer:AbstractSection) < prototype(Neos.Fusion:Tag)
     content = Neos.Fusion:Array {
         legend = Neos.Fusion:Tag {
             tagName = 'legend'
-            content = ${Neos.Form.translateAndEscapeProperty(containerElement, 'label')}
+            content = ${Neos.Form.FusionRenderer.translateAndEscapeProperty(containerElement, 'label')}
             @if.hasLabel = ${containerElement.label ? true : false}
         }
         elements = Neos.Fusion:Collection {

--- a/Resources/Private/Fusion/Core/FormElement.fusion
+++ b/Resources/Private/Fusion/Core/FormElement.fusion
@@ -1,8 +1,8 @@
 prototype(Neos.Form.FusionRenderer:FormElement) < prototype(Neos.Fusion:Array) {
     @context.elementName = ${'--' + formRuntime.identifier + '[' + element.identifier + ']'}
-    @context.elementValue = ${Neos.Form.elementValue(formRuntime, element)}
-    @context.elementValidationErrors = ${Neos.Form.validationErrors(formRuntime, element)}
-    @context.elementHasValidationErrors = ${Neos.Form.hasValidationErrors(formRuntime, element)}
+    @context.elementValue = ${Neos.Form.FusionRenderer.elementValue(formRuntime, element)}
+    @context.elementValidationErrors = ${Neos.Form.FusionRenderer.validationErrors(formRuntime, element)}
+    @context.elementHasValidationErrors = ${Neos.Form.FusionRenderer.hasValidationErrors(formRuntime, element)}
 
     label = Neos.Form.FusionRenderer:FormElementLabel
     fieldContainer = Neos.Form.FusionRenderer:FormElementFieldContainer
@@ -27,7 +27,7 @@ prototype(Neos.Form.FusionRenderer:FormElementLabel) < prototype(Neos.Fusion:Tag
         for = ${element.uniqueIdentifier}
     }
     content = Neos.Fusion:Array {
-        value = ${Neos.Form.translateAndEscapeProperty(element, 'label')}
+        value = ${Neos.Form.FusionRenderer.translateAndEscapeProperty(element, 'label')}
         requiredFlag = Neos.Form.FusionRenderer:RequiredFlag
         requiredFlag.@if.isRequired = ${element.required}
     }

--- a/Resources/Private/Fusion/Core/FormNavigation.fusion
+++ b/Resources/Private/Fusion/Core/FormNavigation.fusion
@@ -3,7 +3,7 @@ prototype(Neos.Form.FusionRenderer:FormNavigation) < prototype(Neos.Fusion:Tag) 
     attributes.class = 'form-navigation'
     content = Neos.Fusion:Array {
         previousButton = Neos.Form.FusionRenderer:FormNavigationButton {
-            label = ${Neos.Form.translate(formRuntime, 'forms.navigation.previousPage', 'Previous page')}
+            label = ${Neos.Form.FusionRenderer.translate(formRuntime, 'forms.navigation.previousPage', 'Previous page')}
             class = ${formRuntime.renderingOptions.previousButtonClassAttribute}
             containerClass = 'previous'
             fieldValue = ${formRuntime.previousPage.index}
@@ -11,14 +11,14 @@ prototype(Neos.Form.FusionRenderer:FormNavigation) < prototype(Neos.Fusion:Tag) 
             @if.previousPageExists = ${formRuntime.previousPage ? true : false}
         }
         nextButton = Neos.Form.FusionRenderer:FormNavigationButton {
-            label = ${Neos.Form.translate(formRuntime, 'forms.navigation.nextPage', 'Next page')}
+            label = ${Neos.Form.FusionRenderer.translate(formRuntime, 'forms.navigation.nextPage', 'Next page')}
             class = ${formRuntime.renderingOptions.nextButtonClassAttribute}
             containerClass = 'next'
             fieldValue = ${formRuntime.nextPage.index}
             @if.nextPageExists = ${formRuntime.nextPage ? true : false}
         }
         submitButton = Neos.Form.FusionRenderer:FormNavigationButton {
-            label = ${formRuntime.renderingOptions.submitButtonLabel ? formRuntime.renderingOptions.submitButtonLabel : Neos.Form.translate(formRuntime, 'forms.navigation.submit', 'Submit')}
+            label = ${formRuntime.renderingOptions.submitButtonLabel ? formRuntime.renderingOptions.submitButtonLabel : Neos.Form.FusionRenderer.translate(formRuntime, 'forms.navigation.submit', 'Submit')}
             class = ${formRuntime.renderingOptions.submitButtonClassAttribute}
             containerClass = 'next submit'
             fieldValue = ${Array.length(formRuntime.pages)}

--- a/Resources/Private/Fusion/Elements/FileUpload.fusion
+++ b/Resources/Private/Fusion/Elements/FileUpload.fusion
@@ -18,7 +18,7 @@ prototype(Neos.Form:FileUpload) < prototype(Neos.Form.FusionRenderer:FormElement
             attributes {
                 type = 'hidden'
                 name = ${elementName + '[originallySubmittedResource][__identity]'}
-                value = ${Neos.Form.identifier(elementValue)}
+                value = ${Neos.Form.FusionRenderer.identifier(elementValue)}
             }
             @if.hasUploadedResource = ${elementValue ? true : false}
         }

--- a/Resources/Private/Fusion/Elements/ImageUpload.fusion
+++ b/Resources/Private/Fusion/Elements/ImageUpload.fusion
@@ -21,7 +21,7 @@ prototype(Neos.Form:ImageUpload) < prototype(Neos.Form.FusionRenderer:FormElemen
             attributes {
                 type = 'hidden'
                 name = ${elementName + '[resource][originallySubmittedResource][__identity]'}
-                value = ${Neos.Form.identifier(elementValue.resource)}
+                value = ${Neos.Form.FusionRenderer.identifier(elementValue.resource)}
             }
             @if.hasUploadedResource = ${elementValue ? true : false}
         }

--- a/Resources/Private/Fusion/Elements/PasswordWithConfirmation.fusion
+++ b/Resources/Private/Fusion/Elements/PasswordWithConfirmation.fusion
@@ -11,7 +11,7 @@ prototype(Neos.Form:PasswordWithConfirmation) < prototype(Neos.Form.FusionRender
         confirmationLabel = Neos.Form.FusionRenderer:FormElementLabel {
             @position = 'after field'
             attributes.for = ${element.uniqueIdentifier + '-confirmation'}
-            content.value = ${Neos.Form.translateAndEscapeProperty(element, 'confirmationLabel')}
+            content.value = ${Neos.Form.FusionRenderer.translateAndEscapeProperty(element, 'confirmationLabel')}
         }
         confirmationField = Neos.Fusion:Tag {
             @position = 'after confirmationLabel'


### PR DESCRIPTION
Adds the custom `FormHelper` Eel Helper as `Neos.Form.FusionRenderer`
to the default context (instead of just `Neos.Form`) and adjusts
references accordingly in order to avoid naming collisions.

Fixes: #16