### PR TITLE
Feature: Include Allow third-party fusion code for fusion forms

### DIFF
--- a/Classes/FusionFormRenderer.php
+++ b/Classes/FusionFormRenderer.php
@@ -40,6 +40,12 @@ class FusionFormRenderer implements RendererInterface
      */
     protected $packageManager;
 
+    /**
+     * @Flow\InjectConfiguration(path="fusionAutoInclude")
+     * @var array
+     */
+    protected $packagesForFusionAutoInclude;
+
     public function setControllerContext(ControllerContext $controllerContext)
     {
         $this->controllerContext = $controllerContext;
@@ -89,10 +95,11 @@ class FusionFormRenderer implements RendererInterface
         $fusionView = new FusionView();
         $fusionView->setControllerContext($this->controllerContext);
         $fusionView->setPackageKey('Neos.Form.FusionRenderer');
-        $fusionView->setFusionPathPatterns([
-            $this->packageManager->getPackage('Neos.Fusion')->getResourcesPath() . 'Private/Fusion',
-            $this->packageManager->getPackage('Neos.Form.FusionRenderer')->getResourcesPath() . 'Private/Fusion',
-        ]);
+
+        $fusionView->setFusionPathPatterns(array_map(function (string $value) {
+            return $this->packageManager->getPackage($value)->getResourcesPath() . 'Private/Fusion';
+        }, array_keys(array_filter($this->packagesForFusionAutoInclude))));
+
         $fusionView->setFusionPath('neos_form');
         $fusionView->assign('formRuntime', $formRuntime);
         return $fusionView->render();

--- a/Classes/FusionFormRenderer.php
+++ b/Classes/FusionFormRenderer.php
@@ -88,13 +88,10 @@ class FusionFormRenderer implements RendererInterface
 
         $fusionView = new FusionView();
         $fusionView->setControllerContext($this->controllerContext);
-        $fusionView->disableFallbackView();
         $fusionView->setPackageKey('Neos.Form.FusionRenderer');
         $fusionView->setFusionPathPatterns([
             $this->packageManager->getPackage('Neos.Fusion')->getResourcesPath() . 'Private/Fusion',
-            $this->packageManager->getPackage('Neos.Form.FusionRenderer')->getResourcesPath() . 'Private/Fusion/Core',
-            $this->packageManager->getPackage('Neos.Form.FusionRenderer')->getResourcesPath() . 'Private/Fusion/ContainerElements',
-            $this->packageManager->getPackage('Neos.Form.FusionRenderer')->getResourcesPath() . 'Private/Fusion/Elements',
+            $this->packageManager->getPackage('Neos.Form.FusionRenderer')->getResourcesPath() . 'Private/Fusion',
         ]);
         $fusionView->setFusionPath('neos_form');
         $fusionView->assign('formRuntime', $formRuntime);

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -13,6 +13,11 @@ Neos:
           'Neos.Form:Form':
             rendererClassName: 'Neos\Form\FusionRenderer\FusionFormRenderer'
 
+    FusionRenderer:
+      fusionAutoInclude:
+        'Neos.Fusion': true
+        'Neos.Form.FusionRenderer': true
+
   Neos:
     fusion:
       autoInclude:

--- a/README.md
+++ b/README.md
@@ -133,7 +133,19 @@ Trying to render it, however, will lead to an exception:
 The Fusion object `Your.Package:EmailAddress` is not completely defined (missing property `@class`). Most likely you didn't inherit from a basic object.
 ```
 
-Let's change this by defining the Fusion object:
+Let's change this.
+
+First configure FusionRenderer to include your custom Fusion code:
+
+```yaml
+Neos:
+  Form:
+    FusionRenderer:
+      fusionAutoInclude:
+        'Your.Package': true
+```
+
+then define the rendering in your own fusion:
 
 *EmailAddressFormElement.fusion*:
 


### PR DESCRIPTION
Fusion code from additional packages can be loaded
using a similar configuration to `Neos.Neos.fusion.autoInclude`

Fixes: #9 