### PR TITLE
BUGFIX: Format DateTime in DatePicker

### DIFF
--- a/Resources/Private/Fusion/Elements/DatePicker.fusion
+++ b/Resources/Private/Fusion/Elements/DatePicker.fusion
@@ -6,6 +6,8 @@ prototype(Neos.Form:DatePicker) < prototype(Neos.Form.FusionRenderer:FormElement
                 type = 'date'
                 name = ${elementName}
                 value = ${elementValue}
+                value.@process.format = ${Date.format(value, 'Y-m-d')}
+                value.@process.format.@if.isDateTime = ${Type.className(elementValue) == 'DateTime'}
             }
         }
     }

--- a/Resources/Private/Fusion/Elements/DatePicker.fusion
+++ b/Resources/Private/Fusion/Elements/DatePicker.fusion
@@ -7,7 +7,7 @@ prototype(Neos.Form:DatePicker) < prototype(Neos.Form.FusionRenderer:FormElement
                 name = ${elementName}
                 value = ${elementValue}
                 value.@process.format = ${Date.format(value, 'Y-m-d')}
-                value.@process.format.@if.isDateTime = ${Type.className(elementValue) == 'DateTime'}
+                value.@process.format.@if.isDateTime = ${Type.instance(elementValue, '\DateTimeInterface')}
             }
         }
     }


### PR DESCRIPTION
Without this change Flow would convert the value to a DateTime object and 
an exception occurs when Fusion tries to convert the object to a string value.