### PR TITLE
Create Frontend Validator for allowed file types

### DIFF
--- a/Classes/Eel/Helper/FormHelper.php
+++ b/Classes/Eel/Helper/FormHelper.php
@@ -32,6 +32,12 @@ class FormHelper implements ProtectedContextAwareInterface
      */
     protected $persistenceManager;
 
+	/**
+	 * @var ?array
+	 * @Flow\InjectConfiguration(path="FusionRenderer.formHelper.mimeTypes", package="Neos.Form")
+	 */
+	protected ?array $mimeTypes;
+
     /**
      * Returns the value of a given Form Element.
      * If there are validation errors for the element, the previously submitted value will be returned.
@@ -198,6 +204,30 @@ class FormHelper implements ProtectedContextAwareInterface
     {
         return htmlspecialchars($string, ENT_QUOTES);
     }
+
+	/**
+	 * Get accept string for input attribute accept based on the allowed extensions array
+	 *
+	 * @param array $allowedExtensions
+	 * @param bool $asFileExtension
+	 * @param bool $asMimeType
+	 * @return string
+	 */
+	public function getAcceptFromAllowedExtensions(array $allowedExtensions, bool $asFileExtension = true, bool $asMimeType = true): string {
+		$accept = [];
+
+		foreach ($allowedExtensions as $key => $extension) {
+			if ($asFileExtension) {
+				$accept[] = '.' . $extension;
+			}
+
+			if ($asMimeType) {
+				$accept[] = $this->mimeTypes && array_key_exists($extension, $this->mimeTypes) ? $this->mimeTypes[$extension] : null;
+			}
+		}
+
+		return implode(', ', $accept);
+	}
 
     /**
      * @param string $methodName

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -20,7 +20,12 @@ Neos:
       formHelper:
         mimeTypes:
           pdf: 'application/pdf'
+          xls: 'application/msexcel'
+          xlsx: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
           doc: 'application/msword'
+          docx: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+          odt: 'application/vnd.oasis.opendocument.text'
+          csv: 'text/csv'
           jpeg: 'image/jpeg'
           png: 'image/png'
           bmp: 'image/bmp'

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -17,6 +17,13 @@ Neos:
       fusionAutoInclude:
         'Neos.Fusion': true
         'Neos.Form.FusionRenderer': true
+      formHelper:
+        mimeTypes:
+          pdf: 'application/pdf'
+          doc: 'application/msword'
+          jpeg: 'image/jpeg'
+          png: 'image/png'
+          bmp: 'image/bmp'
 
   Neos:
     fusion:

--- a/Resources/Private/Fusion/Elements/FileUpload.fusion
+++ b/Resources/Private/Fusion/Elements/FileUpload.fusion
@@ -26,6 +26,7 @@ prototype(Neos.Form:FileUpload) < prototype(Neos.Form.FusionRenderer:FormElement
             tagName = 'input'
             attributes {
                 type = 'file'
+                accept = ${Neos.Form.FusionRenderer.getAcceptFromAllowedExtensions(element.properties.allowedExtensions)}
                 name = ${elementName}
             }
         }


### PR DESCRIPTION
**Problem**: The `FileUpload` form element allows specifying permitted file types, but the current validation occurs only on the backend, specifically in the `\Neos\Form\Validation\FileTypeValidator`. This approach has two major drawbacks:

1. Server Overload: When numerous form submissions occur simultaneously, the server can become overwhelmed, leading to performance degradation or potential downtime.
2. Storage Inefficiency: Files are uploaded and stored on the server even if they fail validation. This results in unnecessary consumption of server storage, as invalid files are saved before being rejected.

To address these issues, it's essential to improve the validation process to prevent server overload and optimize storage usage.

**Implementation**:

1. `accept` Attribute Addition: The `FileUpload` form element now includes an accept attribute, which restricts users from selecting files that are not permitted by the form's configuration. This prevents invalid files from being selected at the client-side, reducing the load on the server.
2. Helper for Parsing `accept` String: A helper function was introduced to generate the accept attribute value based on the allowed file types configured in the form. This helper can parse the allowed file types in three modes: standard, MIME type, or both, depending on the requirements.
3. MIME Type Mapping: The helper function maps MIME types to the allowed file types using the new setting `Neos.Form:FusionRenderer.formHelper.mimeTypes`. This ensures that the accept attribute correctly reflects the permitted file types, enhancing both client-side and server-side validation.

