### PR TITLE
BUGFIX: Preventing the Rendering of UploadedResourcePreview

### DIFF
--- a/Resources/Private/Fusion/Elements/FileUpload.fusion
+++ b/Resources/Private/Fusion/Elements/FileUpload.fusion
@@ -11,6 +11,7 @@ prototype(Neos.Form:FileUpload) < prototype(Neos.Form.FusionRenderer:FormElement
             }
             content = ${elementValue.fileName}
             @if.hasUploadedResource = ${elementValue ? true : false}
+            @if.hasNoValidationErrors = ${!elementHasValidationErrors}
         }
         uploadedResourceHiddenField = Neos.Fusion:Tag {
             @position = 'before field'

--- a/Resources/Private/Fusion/Elements/ImageUpload.fusion
+++ b/Resources/Private/Fusion/Elements/ImageUpload.fusion
@@ -14,6 +14,7 @@ prototype(Neos.Form:ImageUpload) < prototype(Neos.Form.FusionRenderer:FormElemen
                 maximumWidth = 200
             }
             @if.hasUploadedImage = ${elementValue ? true : false}
+            @if.hasNoValidationErrors = ${!elementHasValidationErrors}
         }
         uploadedImageHiddenField =  Neos.Fusion:Tag {
             @position = 'before field'

--- a/Resources/Private/Fusion/Elements/ImageUpload.fusion
+++ b/Resources/Private/Fusion/Elements/ImageUpload.fusion
@@ -30,6 +30,7 @@ prototype(Neos.Form:ImageUpload) < prototype(Neos.Form.FusionRenderer:FormElemen
             tagName = 'input'
             attributes {
                 type = 'file'
+                accept = ${Neos.Form.FusionRenderer.getAcceptFromAllowedExtensions(element.properties.allowedTypes)}
                 name = ${elementName + '[resource]'}
             }
         }


### PR DESCRIPTION
Upon encountering a validation error during the upload process, the generation of the URL is hindered. Consequently, the rendering of the preview for invalid upload elements is suppressed.

Fixes: #33