### PR TITLE
BUGFIX: Downgrad symfony/mime to version 6.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "neos/form": "^5.0",
         "neos/fusion": "^7.3 || ^8.0 || ^9.0",
-        "symfony/mime": "^7.0"
+        "symfony/mime": "^6.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Since version 7 doesn’t work with older PHP versions, and version 6 uses 8.1 and newer, we’ll have to stick with this version.

Fixes: #36